### PR TITLE
simple_form adjustment

### DIFF
--- a/lib/bootstrap-colorpicker-rails/simple_form/colorpicker_input.rb
+++ b/lib/bootstrap-colorpicker-rails/simple_form/colorpicker_input.rb
@@ -1,5 +1,5 @@
 class ColorpickerInput < SimpleForm::Inputs::StringInput
-  def input
+  def input(wrapper_options)
     idf = "#{lookup_model_names.join("_")}_#{reflection_or_attribute_name}"
     script = template.content_tag(:script, type: 'text/javascript') do
       "$('input[id=#{idf}]').colorpicker();".html_safe


### PR DESCRIPTION
DEPRECATION WARNING: input method now accepts a `wrapper_options` argument. The method definition without the argument is deprecated and will be removed in the next Simple Form version. Change your code from:

```
def input
```

to

```
def input(wrapper_options)
```

See https://github.com/plataformatec/simple_form/pull/997 for more information.
